### PR TITLE
Load CSS inline instead of externally

### DIFF
--- a/freetextresponse/mixins/fragment.py
+++ b/freetextresponse/mixins/fragment.py
@@ -5,6 +5,7 @@ Note: We should resume test coverage for all lines in this file once
 split into its own library.
 """
 from __future__ import absolute_import
+import pkg_resources
 
 from xblock.core import XBlock
 from xblock.fragment import Fragment
@@ -78,10 +79,12 @@ class XBlockFragmentBuilderMixin(object):
         for item in css:
             if item.startswith('/'):
                 url = item
+                fragment.add_css_url(url)
             else:
-                item = 'public/' + item
-                url = self.runtime.local_resource_url(self, item)
-            fragment.add_css_url(url)
+                item = '../public/' + item
+                data = pkg_resources.resource_string(__name__, item)
+                data = data.decode('utf8')
+                fragment.add_css(data)
         for item in js:
             item = 'public/' + item
             url = self.runtime.local_resource_url(self, item)


### PR DESCRIPTION
to quickly fix issue [1] where CSS intermittently fails to load in CMS/LMS.

Background:
===========
For some unknown reason, the external stylesheet fails to load in _one_
of the LMS [2] or CMS [3]; though the failure alternates between the
two. So, it will work in CMS but fail in LMS, then the success/failure
switches after several minutes, alternating back and forth. When this
happens, the same computed hash value is used for each service's
resource.

Until additional resources can be devoted to investigating the root
cause, let's simply load the stylesheet inline;
the file size is 3.1K.

References:
===========
- [1] TNL-7084
- [2] HTTP 403 via CDN
- [3] HTTP 404 via nginx