### PR TITLE
Change heading from H2 to H3

### DIFF
--- a/freetextresponse/templates/view.html
+++ b/freetextresponse/templates/view.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="freetextresponse xmodule_display xmodule_CapaModule problem">
-    <h2 class="problem-header">{{ display_name }}</h2>
+    <h3 class="problem-header">{{ display_name }}</h3>
     <div class="problem-progress">{{ problem_progress }}</div>
     <p>{{ prompt|safe }}</p>
     <div class="word-count-message">{{ word_count_message }}</div>


### PR DESCRIPTION
Minor change to switch the heading from h2 to h3

# Overview
Minor amendment as H2 is the wrong heading level for this component - Problem component headings are H3 so it's inconsistent, and as unit headings are H2 these should come down to H3 for accessibility reasons.

# Test Instructions
- Checkout the branch
- Update settings?
- Anything else?

# TODO
- [ ] Compile static assets
- [ ] Lint all files
- [ ] Pass all tests
- [ ] Bump the version number in `setup.py`
- [ ] Attach screenshots?
- [ ] Code Reviewer 1:
- [ ] Code Reviewer 2:
- [ ] Submit PR against `edx-platform` to bump the version
- [ ] Upload to PyPi
