### PR TITLE
Remove enum34 dependency since we don't need it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.1.1
+* Removed support of enum34 package
+
 ## Version 1.1.0
 * Removed support of Django < 2.2 versions
 * Added support for python 3.8

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,6 @@
 -c constraints.txt
 
 Django
-enum34
 six
 XBlock
 xblock-utils

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path
 from setuptools import setup
 
 
-version = '1.1.0'
+version = '1.1.1'
 description = __doc__.strip().split('\n')[0]
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.rst')) as file_in:


### PR DESCRIPTION
on python3.8