### PR TITLE
build: save common_constraints.txt locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,13 @@ $(module_root)/public/%.css: $(module_root)/public/%.less
 test: requirements  ## Run all quality checks and unit tests
 	tox -p all
 
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q -r requirements/pip_tools.txt
 	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via fs
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
 fs==2.4.13
     # via xblock

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,26 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<2.3
+
+# docutils version 0.17 is causing docs rendering to fail
+# See https://sourceforge.net/p/docutils/bugs/417/
+docutils==0.16
+
+# latest version is causing e2e failures in edx-platform.
+drf-jwt<1.19.1
+
+# Newer versions causing tests failures in multiple repos.
+pyjwt[crypto]==1.7.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,6 +9,6 @@
 # linking to it here is good.
 
 # Common constraints for edx repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+-c common_constraints.txt
 
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -28,7 +28,7 @@ django-pyfs==3.0
     # via -r requirements/test.txt
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django-pyfs

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,7 +20,7 @@ django-pyfs==3.0
     # via -r requirements/test.in
 django==2.2.24
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   django-pyfs
     #   xblock-sdk
 edx-opaque-keys==2.2.1


### PR DESCRIPTION
so that dependabot can access the constraints file and automatically
create security PRs; it fails if the constraints file is specified via
remote URL.