### PR TITLE
fix: add backward-compatible ResourceLoader import in fragment.py

### DIFF
--- a/freetextresponse/mixins/fragment.py
+++ b/freetextresponse/mixins/fragment.py
@@ -5,7 +5,11 @@ Note: We should resume test coverage for all lines in this file once
 split into its own library.
 """
 from xblock.core import XBlock
-from xblock.utils.resources import ResourceLoader
+try:
+    from xblock.utils.resources import ResourceLoader
+except ModuleNotFoundError:
+    from xblockutils.resources import ResourceLoader
+
 from web_fragments.fragment import Fragment
 
 


### PR DESCRIPTION
`freetextresponse/mixins/fragment.py` was importing `ResourceLoader` directly `from xblock.utils.resources`, which raises `ModuleNotFoundError` on Open edX releases older than Quince. Added a `try/except` fallback to `import from xblockutils.resources `instead — matching the same pattern already used in `views.py` and `mixins/scenario.py`.